### PR TITLE
Added enqueueWithDelay.kt with tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
             }
         }

--- a/readme.md
+++ b/readme.md
@@ -171,3 +171,5 @@ val fastProgress = fastProgressFlow()
 
 fun fastProgressFlow(): Flow<Int> = flow<Int> { repeat(10) { emit(it) } }
 ```
+
+See [implementation](https://github.com/savvasenok/kotlin-coroutines-recipes/blob/master/src/commonMain/kotlin/enqueueWithDelay.kt).

--- a/readme.md
+++ b/readme.md
@@ -159,3 +159,15 @@ fun observeUserState(userId: String): Flow<User> = usersState.get(userId)
 ```
 
 See [implementation](https://github.com/MarcinMoskala/kotlin-coroutines-recipes/blob/master/src/commonMain/kotlin/StateDataSource.kt).
+
+## `enqueueWithDelay`
+
+Function `enqueueWithDelay` transforms flow into a queue, where there is a given wait-`period` between two consecutive emits from original flow. Useful for displaying fast-changing info to the user, like progress state.
+
+```kotlin
+val fastProgress = fastProgressFlow()
+    .enqueueWithDelay(period = 1.seconds)
+    .map(::toSomeUiState)
+
+fun fastProgressFlow(): Flow<Int> = flow<Int> { repeat(10) { emit(it) } }
+```

--- a/readme.md
+++ b/readme.md
@@ -172,4 +172,4 @@ val fastProgress = fastProgressFlow()
 fun fastProgressFlow(): Flow<Int> = flow<Int> { repeat(10) { emit(it) } }
 ```
 
-See [implementation](https://github.com/savvasenok/kotlin-coroutines-recipes/blob/master/src/commonMain/kotlin/enqueueWithDelay.kt).
+See [implementation](https://github.com/MarcinMoskala/kotlin-coroutines-recipes/blob/master/src/commonMain/kotlin/enqueueWithDelay.kt).

--- a/src/commonMain/kotlin/enqueueWithDelay.kt
+++ b/src/commonMain/kotlin/enqueueWithDelay.kt
@@ -1,0 +1,31 @@
+package recipes
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+import kotlinx.datetime.Clock
+import kotlin.math.max
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Emits value every [period], if there is one. Emits immediately, if time between
+ * two consecutively emitted values is greater or equals [period]
+ * */
+fun <T> Flow<T>.enqueueWithDelay(period: Duration = 1.seconds): Flow<T> {
+    val periodMs = period.inWholeMilliseconds
+    return flow {
+        var lastEmitTime = 0L
+        this@enqueueWithDelay.collect { value ->
+            val currentTime = currentTimeMillis()
+            val elapsedTime = currentTime - lastEmitTime
+
+            val waitTime = max(periodMs - elapsedTime, 0)
+            if (waitTime > 0) delay(waitTime)
+
+            emit(value)
+            lastEmitTime = currentTimeMillis()
+        }
+    }
+}
+
+private fun currentTimeMillis(): Long = Clock.System.now().toEpochMilliseconds()

--- a/src/commonMain/kotlin/enqueueWithDelay.kt
+++ b/src/commonMain/kotlin/enqueueWithDelay.kt
@@ -3,7 +3,6 @@ package recipes
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.datetime.Clock
-import kotlin.math.max
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
@@ -19,7 +18,7 @@ fun <T> Flow<T>.enqueueWithDelay(period: Duration = 1.seconds): Flow<T> {
             val currentTime = currentTimeMillis()
             val elapsedTime = currentTime - lastEmitTime
 
-            val waitTime = max(periodMs - elapsedTime, 0)
+            val waitTime = periodMs - elapsedTime
             if (waitTime > 0) delay(waitTime)
 
             emit(value)

--- a/src/commonTest/kotlin/EnqueueWithDelayTest.kt
+++ b/src/commonTest/kotlin/EnqueueWithDelayTest.kt
@@ -1,0 +1,72 @@
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import recipes.enqueueWithDelay
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+
+private val EMIT_RATE = 500.milliseconds
+private val VERY_SLOW = EMIT_RATE.times(2)
+private val VERY_FAST = EMIT_RATE.div(2)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EnqueueWithDelayTest {
+
+    private fun dataFlow(n: Int): Flow<Int> = flow {
+        repeat(n) {
+            emit(it)
+            delay(EMIT_RATE)
+        }
+    }
+
+    @Test
+    fun period_greater_than_flow_rate() = runTest {
+
+        val period = VERY_SLOW
+        var time = 0L
+
+        withContext(Dispatchers.Default) {
+            dataFlow(10)
+                .enqueueWithDelay(period = period)
+                .onEach {
+                    val current = currentTimeMillis()
+                    val delta = current - time
+
+                    if (delta < period.inWholeMilliseconds)
+                        assertEquals(period.inWholeMilliseconds, delta)
+
+                    time = current
+                }
+                .toList()
+        }
+    }
+
+    @Test
+    fun period_smaller_than_flow_rate() = runTest {
+
+        val period = VERY_FAST
+        var time = 0L
+
+        withContext(Dispatchers.Default) {
+            dataFlow(10)
+                .enqueueWithDelay(period = period)
+                .onEach {
+                    val current = currentTimeMillis()
+                    val delta = current - time
+
+                    if (delta < period.inWholeMilliseconds)
+                        assertEquals(period.inWholeMilliseconds, delta)
+
+                    time = current
+                }
+                .toList()
+        }
+    }
+
+    private fun currentTimeMillis(): Long = Clock.System.now().toEpochMilliseconds()
+}


### PR DESCRIPTION
Added new flow modifier, that ensures there is a specified delay between two consecutive emits from the flow (at least specified amount or more)

I wrote tests, that require `Dispatchers.Default` for a `delay(...)` to work. This adds a lot of time to run unit tests now, but I could not find a better solution. Please let me know, if you know how to do it